### PR TITLE
Add support::units module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,38 +3,19 @@
 version = 4
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "indexmap"
-version = "2.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
 
 [[package]]
 name = "num-traits"
@@ -43,16 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
-dependencies = [
- "fixedbitset",
- "indexmap",
 ]
 
 [[package]]
@@ -106,23 +77,18 @@ dependencies = [
 
 [[package]]
 name = "twine-core"
-version = "0.4.2"
-source = "git+https://github.com/isentropic-dev/twine.git?branch=main#3c6a14b56706f42a1626fbf2b0c4d8fdf0423ff6"
-dependencies = [
- "num-traits",
- "petgraph",
- "thiserror",
- "uom 0.37.0",
-]
+version = "0.5.0"
+source = "git+https://github.com/isentropic-dev/twine.git?branch=main#3050a17cd6e9fe7c3f00050839bf3a26176aa04d"
 
 [[package]]
 name = "twine-models"
 version = "0.1.0"
 dependencies = [
+ "approx",
  "num-traits",
  "thiserror",
  "twine-core",
- "uom 0.36.0",
+ "uom",
 ]
 
 [[package]]
@@ -142,16 +108,6 @@ name = "uom"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffd36e5350a65d112584053ee91843955826bf9e56ec0d1351214e01f6d7cd9c"
-dependencies = [
- "num-traits",
- "typenum",
-]
-
-[[package]]
-name = "uom"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd5cfe7d84f6774726717f358a37f5bca8fca273bed4de40604ad129d1107b49"
 dependencies = [
  "num-traits",
  "typenum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ thiserror = "2.0"
 # TODO: Switch to version dependency once twine-core 0.5 is published to crates.io
 twine-core = { git = "https://github.com/isentropic-dev/twine.git", branch = "main" }
 uom = "0.36"
+
+[dev-dependencies]
+approx = "0.5"

--- a/src/support.rs
+++ b/src/support.rs
@@ -3,3 +3,4 @@
 //! Each exported module is a self-contained utility with its own APIs and design.
 
 pub mod constraint;
+pub mod units;

--- a/src/support/units.rs
+++ b/src/support/units.rs
@@ -1,0 +1,31 @@
+//! Extensions to [`uom`].
+//!
+//! This crate uses [`uom`] for all physical units (e.g., temperature, pressure, power).
+//! This module provides extensions that are useful for modeling but aren't included in [`uom`].
+//!
+//! ## Temperature differences
+//!
+//! The [`TemperatureDifference`] trait provides a [`minus`](TemperatureDifference::minus) method
+//! for subtracting one absolute temperature from another to get a temperature interval:
+//!
+//! ```
+//! use uom::si::f64::ThermodynamicTemperature;
+//! use uom::si::thermodynamic_temperature::kelvin;
+//! use twine_models::support::units::TemperatureDifference;
+//!
+//! let t1 = ThermodynamicTemperature::new::<kelvin>(300.0);
+//! let t2 = ThermodynamicTemperature::new::<kelvin>(250.0);
+//! let delta_t = t1.minus(t2);
+//! // delta_t is a TemperatureInterval, not a ThermodynamicTemperature
+//! ```
+//!
+//! This extension trait is currently needed due to limitations in [`uom`].
+//! See [`TemperatureDifference`] for details.
+
+mod quantities;
+mod temperature_difference;
+
+pub use quantities::{
+    SpecificEnthalpy, SpecificEntropy, SpecificGasConstant, SpecificInternalEnergy,
+};
+pub use temperature_difference::TemperatureDifference;

--- a/src/support/units/quantities.rs
+++ b/src/support/units/quantities.rs
@@ -1,0 +1,16 @@
+use uom::{
+    si::{ISQ, Quantity, SI},
+    typenum::{N1, N2, P2, Z0},
+};
+
+/// Specific gas constant, J/kg·K in SI.
+pub type SpecificGasConstant = Quantity<ISQ<P2, Z0, N2, Z0, N1, Z0, Z0>, SI<f64>, f64>;
+
+/// Specific enthalpy, J/kg in SI.
+pub type SpecificEnthalpy = Quantity<ISQ<P2, Z0, N2, Z0, Z0, Z0, Z0>, SI<f64>, f64>;
+
+/// Specific entropy, J/kg·K in SI.
+pub type SpecificEntropy = Quantity<ISQ<P2, Z0, N2, Z0, N1, Z0, Z0>, SI<f64>, f64>;
+
+/// Specific internal energy, J/kg in SI.
+pub type SpecificInternalEnergy = Quantity<ISQ<P2, Z0, N2, Z0, Z0, Z0, Z0>, SI<f64>, f64>;

--- a/src/support/units/temperature_difference.rs
+++ b/src/support/units/temperature_difference.rs
@@ -1,0 +1,64 @@
+use uom::si::{
+    f64::{TemperatureInterval, ThermodynamicTemperature},
+    temperature_interval::kelvin as delta_kelvin,
+    thermodynamic_temperature::kelvin as abs_kelvin,
+};
+
+/// Extension trait for computing temperature differences.
+///
+/// This trait provides a [`minus`](Self::minus) method that subtracts two
+/// [`ThermodynamicTemperature`] values (absolute temperatures) and returns a
+/// [`TemperatureInterval`] (temperature difference).
+///
+/// For background on this distinction and why this extension is needed:
+/// [#380](https://github.com/iliekturtles/uom/issues/380),
+/// [#289](https://github.com/iliekturtles/uom/issues/289),
+/// [#403](https://github.com/iliekturtles/uom/issues/403).
+///
+/// [`TemperatureInterval`]: uom::si::f64::TemperatureInterval
+/// [`ThermodynamicTemperature`]: uom::si::f64::ThermodynamicTemperature
+pub trait TemperatureDifference {
+    /// Returns the temperature difference `self - other`.
+    fn minus(self, other: Self) -> TemperatureInterval;
+}
+
+impl TemperatureDifference for ThermodynamicTemperature {
+    fn minus(self, other: Self) -> TemperatureInterval {
+        TemperatureInterval::new::<delta_kelvin>(
+            self.get::<abs_kelvin>() - other.get::<abs_kelvin>(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use approx::assert_relative_eq;
+    use uom::si::{
+        f64::ThermodynamicTemperature,
+        temperature_interval::{degree_celsius as delta_celsius, kelvin as delta_kelvin},
+        thermodynamic_temperature::{degree_celsius, degree_fahrenheit, kelvin as abs_kelvin},
+    };
+
+    #[test]
+    fn subtract_temperatures() {
+        let t1 = ThermodynamicTemperature::new::<abs_kelvin>(300.0);
+        let t2 = ThermodynamicTemperature::new::<abs_kelvin>(310.0);
+
+        // Positive temperature change.
+        assert_relative_eq!(t2.minus(t1).get::<delta_kelvin>(), 10.0);
+
+        // Negative temperature change.
+        assert_relative_eq!(t1.minus(t2).get::<delta_celsius>(), -10.0);
+
+        // No difference in temperature between 25°C and 77°F.
+        let t_in_c = ThermodynamicTemperature::new::<degree_celsius>(25.0);
+        let t_in_f = ThermodynamicTemperature::new::<degree_fahrenheit>(77.0);
+        assert_relative_eq!(
+            t_in_f.minus(t_in_c).get::<delta_celsius>(),
+            0.0,
+            epsilon = 1e-12
+        );
+    }
+}


### PR DESCRIPTION
This PR adds a `support::units` module with extensions to `uom`. Includes the `TemperatureDifference` trait for subtracting absolute temperatures and specific quantity type aliases (specific enthalpy, entropy, gas constant, internal energy).
