### PR TITLE
Add support::constraint module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Set up cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets -- -W clippy::pedantic -D warnings
+
+      - name: Run tests
+        run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,156 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "twine-core"
+version = "0.4.2"
+source = "git+https://github.com/isentropic-dev/twine.git?branch=main#3c6a14b56706f42a1626fbf2b0c4d8fdf0423ff6"
+dependencies = [
+ "num-traits",
+ "petgraph",
+ "thiserror",
+ "uom 0.37.0",
+]
+
+[[package]]
 name = "twine-models"
 version = "0.1.0"
+dependencies = [
+ "num-traits",
+ "thiserror",
+ "twine-core",
+ "uom 0.36.0",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "uom"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd36e5350a65d112584053ee91843955826bf9e56ec0d1351214e01f6d7cd9c"
+dependencies = [
+ "num-traits",
+ "typenum",
+]
+
+[[package]]
+name = "uom"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd5cfe7d84f6774726717f358a37f5bca8fca273bed4de40604ad129d1107b49"
+dependencies = [
+ "num-traits",
+ "typenum",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,11 @@ authors = ["Isentropic Development <info@isentropic.dev>"]
 license = "MIT"
 repository = "https://github.com/isentropic-dev/twine-models"
 readme = "README.md"
-description = "Opinionated, domain-specific models and model-building tools for Twine"
+description = "Domain-specific models and model-building tools for Twine"
 
 [dependencies]
+num-traits = "0.2"
+thiserror = "2.0"
+# TODO: Switch to version dependency once twine-core 0.5 is published to crates.io
+twine-core = { git = "https://github.com/isentropic-dev/twine.git", branch = "main" }
+uom = "0.36"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Twine Models
 
-Opinionated, domain-specific models and model-building tools for [Twine](https://github.com/isentropic-dev/twine).
+Domain-specific models and model-building tools for [Twine](https://github.com/isentropic-dev/twine).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 //! # Twine Models
 //!
-//! Opinionated, domain-specific models and model-building tools for
+//! Domain-specific models and model-building tools for
 //! [Twine](https://github.com/isentropic-dev/twine).
+//!
+//! This crate provides opinionated model implementations and supporting
+//! utilities organized around engineering domains.
 //!
 //! ## Crate layout
 //!

--- a/src/support.rs
+++ b/src/support.rs
@@ -1,3 +1,5 @@
 //! Supporting utilities for models.
 //!
 //! Each exported module is a self-contained utility with its own APIs and design.
+
+pub mod constraint;

--- a/src/support/constraint.rs
+++ b/src/support/constraint.rs
@@ -1,0 +1,152 @@
+//! Type-level numeric constraints with zero runtime cost.
+//!
+//! This module provides types that express numeric constraints like "non-negative",
+//! "non-zero", or "strictly positive" at the type level, with zero runtime
+//! overhead after construction.
+//!
+//! These types ensure values always satisfy the required numeric constraints,
+//! leading to safer and more self-documenting designs.
+//!
+//! # Provided constraints
+//!
+//! The following marker types are available:
+//!
+//! - [`NonNegative`]: Zero or greater
+//! - [`NonPositive`]: Zero or less
+//! - [`NonZero`]: Not equal to zero
+//! - [`StrictlyNegative`]: Less than zero
+//! - [`StrictlyPositive`]: Greater than zero
+//! - [`UnitInterval`]: Closed unit interval `0 ≤ x ≤ 1`
+//! - [`UnitIntervalOpen`]: Open unit interval `0 < x < 1`
+//! - [`UnitIntervalLowerOpen`]: Lower-open unit interval `0 < x ≤ 1`
+//! - [`UnitIntervalUpperOpen`]: Upper-open unit interval `0 ≤ x < 1`
+//!
+//! Each marker is used with the generic [`Constrained<T, C>`] wrapper,
+//! where `C` is the marker type implementing [`Constraint<T>`].
+//!
+//! For convenience, each marker also provides an associated `new()`
+//! constructor (e.g., `StrictlyPositive::new(5.0)`).
+//!
+//! See the documentation and tests for each constraint for usage patterns.
+//!
+//! # Extending
+//!
+//! You can define custom numeric invariants by implementing [`Constraint<T>`]
+//! for your own zero-sized marker types.
+
+mod non_negative;
+mod non_positive;
+mod non_zero;
+mod strictly_negative;
+mod strictly_positive;
+mod unit_interval;
+
+use std::{iter::Sum, marker::PhantomData, ops::Add};
+
+use num_traits::Zero;
+use thiserror::Error;
+
+pub use non_negative::NonNegative;
+pub use non_positive::NonPositive;
+pub use non_zero::NonZero;
+pub use strictly_negative::StrictlyNegative;
+pub use strictly_positive::StrictlyPositive;
+pub use unit_interval::{
+    UnitBounds, UnitInterval, UnitIntervalLowerOpen, UnitIntervalOpen, UnitIntervalUpperOpen,
+};
+
+/// A trait for enforcing numeric invariants at construction time.
+///
+/// Implement this trait for any marker type representing a numeric constraint,
+/// such as [`NonNegative`] or [`StrictlyPositive`].
+pub trait Constraint<T> {
+    /// Checks that the given value satisfies this constraint.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConstraintError`] if the value does not satisfy the constraint.
+    fn check(value: &T) -> Result<(), ConstraintError>;
+}
+
+/// An error returned when a [`Constraint`] is violated.
+///
+/// This enum is marked `#[non_exhaustive]` and may include additional variants
+/// in future releases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum ConstraintError {
+    #[error("value must not be negative")]
+    Negative,
+    #[error("value must not be positive")]
+    Positive,
+    #[error("value must not be zero")]
+    Zero,
+    #[error("value is not a number")]
+    NotANumber,
+    #[error("value is below the minimum allowed")]
+    BelowMinimum,
+    #[error("value is above the maximum allowed")]
+    AboveMaximum,
+}
+
+/// A result type alias to use with [`Constraint`].
+pub type ConstraintResult<T, E = ConstraintError> = Result<T, E>;
+
+/// A wrapper enforcing a numeric constraint at construction time.
+///
+/// Combine this with one of the provided marker types (such as [`NonNegative`])
+/// or your own [`Constraint<T>`] implementation.
+///
+/// # Example
+///
+/// ```
+/// use twine_models::support::constraint::{Constrained, StrictlyPositive};
+///
+/// let n = Constrained::<_, StrictlyPositive>::new(42).unwrap();
+/// assert_eq!(n.into_inner(), 42);
+/// ```
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Constrained<T, C: Constraint<T>> {
+    value: T,
+    _marker: PhantomData<C>,
+}
+
+impl<T, C: Constraint<T>> Constrained<T, C> {
+    /// Constructs a new constrained value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the value does not satisfy the constraint.
+    pub fn new(value: T) -> Result<Self, ConstraintError> {
+        C::check(&value)?;
+        Ok(Self {
+            value,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Consumes the wrapper and returns the inner value.
+    pub fn into_inner(self) -> T {
+        self.value
+    }
+}
+
+/// Returns a reference to the inner unconstrained value.
+impl<T, C: Constraint<T>> AsRef<T> for Constrained<T, C> {
+    fn as_ref(&self) -> &T {
+        &self.value
+    }
+}
+
+/// Sums constrained values for which addition is valid.
+///
+/// Applies to all constraints that are preserved under addition.
+impl<T, C> Sum for Constrained<T, C>
+where
+    C: Constraint<T>,
+    Constrained<T, C>: Add<Output = Self> + Zero,
+{
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), |a, b| a + b)
+    }
+}

--- a/src/support/constraint/non_negative.rs
+++ b/src/support/constraint/non_negative.rs
@@ -1,0 +1,154 @@
+use std::{cmp::Ordering, marker::PhantomData, ops::Add};
+
+use num_traits::Zero;
+
+use super::{Constrained, Constraint, ConstraintError};
+
+/// Marker type enforcing that a value is non-negative (zero or greater).
+///
+/// Use this type with [`Constrained<T, NonNegative>`] to encode non-negativity
+/// at the type level.
+///
+/// You can construct a value constrained to be non-negative using either the
+/// generic [`Constrained::new`] method or the convenient [`NonNegative::new`]
+/// associated function.
+///
+/// # Examples
+///
+/// ```
+/// use twine_models::support::constraint::{Constrained, NonNegative};
+///
+/// // Generic constructor:
+/// let x = Constrained::<_, NonNegative>::new(5).unwrap();
+/// assert_eq!(x.into_inner(), 5);
+///
+/// // Associated constructor:
+/// let y = NonNegative::new(0.0).unwrap();
+/// assert_eq!(y.into_inner(), 0.0);
+///
+/// // Error cases:
+/// assert!(NonNegative::new(-7).is_err());
+/// assert!(NonNegative::new(f64::NAN).is_err());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct NonNegative;
+
+impl NonNegative {
+    /// Constructs a [`Constrained<T, NonNegative>`] if the value is non-negative.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the value is negative or not a number (`NaN`).
+    pub fn new<T: PartialOrd + Zero>(
+        value: T,
+    ) -> Result<Constrained<T, NonNegative>, ConstraintError> {
+        Constrained::<T, NonNegative>::new(value)
+    }
+
+    /// Returns the additive identity (zero) as a non-negative constrained value.
+    ///
+    /// This method is equivalent to [`Constrained::<T, NonNegative>::zero()`].
+    #[must_use]
+    pub fn zero<T: PartialOrd + Zero>() -> Constrained<T, NonNegative> {
+        Constrained::<T, NonNegative>::zero()
+    }
+}
+
+impl<T: PartialOrd + Zero> Constraint<T> for NonNegative {
+    fn check(value: &T) -> Result<(), ConstraintError> {
+        match value.partial_cmp(&T::zero()) {
+            Some(Ordering::Greater | Ordering::Equal) => Ok(()),
+            Some(Ordering::Less) => Err(ConstraintError::Negative),
+            None => Err(ConstraintError::NotANumber),
+        }
+    }
+}
+
+/// Adds two `Constrained<T, NonNegative>` values.
+///
+/// Assumes that summing two non-negative values yields a non-negative result.
+/// This holds for most numeric types (`i32`, `f64`, `uom::Quantity`, etc.),
+/// but may not for all possible `T`.
+/// The invariant is checked in debug builds.
+///
+/// # Panics
+///
+/// Panics in debug builds if the sum is unexpectedly negative.
+impl<T> Add for Constrained<T, NonNegative>
+where
+    T: Add<Output = T> + PartialOrd + Zero,
+{
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        let value = self.value + rhs.value;
+        debug_assert!(
+            value >= T::zero(),
+            "Addition produced a negative value, violating NonNegative bound invariant"
+        );
+        Self {
+            value,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> Zero for Constrained<T, NonNegative>
+where
+    T: PartialOrd + Zero,
+{
+    fn zero() -> Self {
+        Self {
+            value: T::zero(),
+            _marker: PhantomData,
+        }
+    }
+
+    fn is_zero(&self) -> bool {
+        self.value == T::zero()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use uom::si::{f64::MassRate, mass_rate::kilogram_per_second};
+
+    #[test]
+    fn integers() {
+        let one = Constrained::<i32, NonNegative>::new(1).unwrap();
+        assert_eq!(one.into_inner(), 1);
+
+        let two = NonNegative::new(2).unwrap();
+        assert_eq!(two.as_ref(), &2);
+
+        let zero = NonNegative::zero();
+        assert_eq!(zero.into_inner(), 0);
+
+        let sum = one + two + zero;
+        assert_eq!(sum.into_inner(), 3);
+
+        assert!(NonNegative::new(-1).is_err());
+    }
+
+    #[test]
+    fn floats() {
+        assert!(Constrained::<f64, NonNegative>::new(2.0).is_ok());
+        assert!(NonNegative::new(0.0).is_ok());
+        assert!(NonNegative::new(-2.0).is_err());
+        assert!(NonNegative::new(f64::NAN).is_err());
+    }
+
+    #[test]
+    fn mass_rates() {
+        let mass_rate = MassRate::new::<kilogram_per_second>(5.0);
+        assert!(NonNegative::new(mass_rate).is_ok());
+
+        let mass_rate = MassRate::new::<kilogram_per_second>(0.0);
+        assert!(NonNegative::new(mass_rate).is_ok());
+
+        let mass_rate = MassRate::new::<kilogram_per_second>(-2.0);
+        assert!(NonNegative::new(mass_rate).is_err());
+    }
+}

--- a/src/support/constraint/non_positive.rs
+++ b/src/support/constraint/non_positive.rs
@@ -1,0 +1,154 @@
+use std::{cmp::Ordering, marker::PhantomData, ops::Add};
+
+use num_traits::Zero;
+
+use super::{Constrained, Constraint, ConstraintError};
+
+/// Marker type enforcing that a value is non-positive (zero or less).
+///
+/// Use this type with [`Constrained<T, NonPositive>`] to encode non-positivity
+/// at the type level.
+///
+/// You can construct a value constrained to be non-positive using either the
+/// generic [`Constrained::new`] method or the convenient [`NonPositive::new`]
+/// associated function.
+///
+/// # Examples
+///
+/// ```
+/// use twine_models::support::constraint::{Constrained, NonPositive};
+///
+/// // Generic constructor:
+/// let x = Constrained::<_, NonPositive>::new(0).unwrap();
+/// assert_eq!(x.into_inner(), 0);
+///
+/// // Associated constructor:
+/// let y = NonPositive::new(-5).unwrap();
+/// assert_eq!(y.into_inner(), -5);
+///
+/// // Error cases:
+/// assert!(NonPositive::new(3).is_err());
+/// assert!(NonPositive::new(f64::NAN).is_err());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NonPositive;
+
+impl NonPositive {
+    /// Constructs a [`Constrained<T, NonPositive>`] if the value is non-positive.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the value is positive or not a number (`NaN`).
+    pub fn new<T: PartialOrd + Zero>(
+        value: T,
+    ) -> Result<Constrained<T, NonPositive>, ConstraintError> {
+        Constrained::<T, NonPositive>::new(value)
+    }
+
+    /// Returns the additive identity (zero) as a non-positive constrained value.
+    ///
+    /// This method is equivalent to [`Constrained::<T, NonPositive>::zero()`].
+    #[must_use]
+    pub fn zero<T: PartialOrd + Zero>() -> Constrained<T, NonPositive> {
+        Constrained::<T, NonPositive>::zero()
+    }
+}
+
+impl<T: PartialOrd + Zero> Constraint<T> for NonPositive {
+    fn check(value: &T) -> Result<(), ConstraintError> {
+        match value.partial_cmp(&T::zero()) {
+            Some(Ordering::Less | Ordering::Equal) => Ok(()),
+            Some(Ordering::Greater) => Err(ConstraintError::Positive),
+            None => Err(ConstraintError::NotANumber),
+        }
+    }
+}
+
+/// Adds two `Constrained<T, NonPositive>` values.
+///
+/// Assumes that summing two non-positive values yields a non-positive result.
+/// This holds for most numeric types (`i32`, `f64`, `uom::Quantity`, etc.),
+/// but may not for all possible `T`.
+/// The invariant is checked in debug builds.
+///
+/// # Panics
+///
+/// Panics in debug builds if the sum is unexpectedly positive.
+impl<T> Add for Constrained<T, NonPositive>
+where
+    T: Add<Output = T> + PartialOrd + Zero,
+{
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        let value = self.value + rhs.value;
+        debug_assert!(
+            value <= T::zero(),
+            "Addition produced a positive value, violating NonPositive bound invariant"
+        );
+        Self {
+            value,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> Zero for Constrained<T, NonPositive>
+where
+    T: PartialOrd + Zero,
+{
+    fn zero() -> Self {
+        Self {
+            value: T::zero(),
+            _marker: PhantomData,
+        }
+    }
+
+    fn is_zero(&self) -> bool {
+        self.value == T::zero()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use uom::si::{f64::Power, power::watt};
+
+    #[test]
+    fn integers() {
+        let neg_one = Constrained::<i32, NonPositive>::new(-1).unwrap();
+        assert_eq!(neg_one.into_inner(), -1);
+
+        let neg_two = NonPositive::new(-2).unwrap();
+        assert_eq!(neg_two.as_ref(), &-2);
+
+        let zero = NonPositive::zero();
+        assert_eq!(zero.into_inner(), 0);
+
+        let sum = neg_one + neg_two + zero;
+        assert_eq!(sum.into_inner(), -3);
+
+        assert!(NonPositive::new(2).is_err());
+    }
+
+    #[test]
+    fn floats() {
+        assert!(Constrained::<f64, NonPositive>::new(-2.0).is_ok());
+        assert!(NonPositive::new(0.0).is_ok());
+        assert!(NonPositive::new(2.0).is_err());
+        assert!(NonPositive::new(f64::NAN).is_err());
+    }
+
+    #[test]
+    fn powers() {
+        let neg_mass_rate = Power::new::<watt>(-5.0);
+        assert!(NonPositive::new(neg_mass_rate).is_ok());
+
+        let zero_mass_rate = Power::new::<watt>(0.0);
+        assert!(NonPositive::new(zero_mass_rate).is_ok());
+
+        let pos_mass_rate = Power::new::<watt>(2.0);
+        assert!(NonPositive::new(pos_mass_rate).is_err());
+    }
+}

--- a/src/support/constraint/non_zero.rs
+++ b/src/support/constraint/non_zero.rs
@@ -1,0 +1,80 @@
+use std::cmp::Ordering;
+
+use num_traits::Zero;
+
+use super::{Constrained, Constraint, ConstraintError};
+
+/// Marker type enforcing that a value is non-zero (not equal to zero).
+///
+/// Use this type with [`Constrained<T, NonZero>`] to encode a non-zero
+/// constraint at the type level.
+///
+/// You can construct a value constrained to be non-zero using either the
+/// generic [`Constrained::new`] method or the convenient [`NonZero::new`]
+/// associated function.
+///
+/// # Examples
+///
+/// ```
+/// use twine_models::support::constraint::{Constrained, NonZero};
+///
+/// // Generic constructor:
+/// let x = Constrained::<_, NonZero>::new(1).unwrap();
+/// assert_eq!(x.into_inner(), 1);
+///
+/// // Associated constructor:
+/// let y = NonZero::new(-5.0).unwrap();
+/// assert_eq!(y.into_inner(), -5.0);
+///
+/// // Error cases:
+/// assert!(NonZero::new(0).is_err());
+/// assert!(NonZero::new(0.0).is_err());
+/// assert!(NonZero::new(f64::NAN).is_err());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NonZero;
+
+impl NonZero {
+    /// Constructs a [`Constrained<T, NonZero>`] if the value is not zero.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the value is zero or not a number (`NaN`).
+    pub fn new<T: PartialOrd + Zero>(value: T) -> Result<Constrained<T, NonZero>, ConstraintError> {
+        Constrained::<T, NonZero>::new(value)
+    }
+}
+
+impl<T: PartialOrd + Zero> Constraint<T> for NonZero {
+    fn check(value: &T) -> Result<(), ConstraintError> {
+        match value.partial_cmp(&T::zero()) {
+            Some(Ordering::Greater | Ordering::Less) => Ok(()),
+            Some(Ordering::Equal) => Err(ConstraintError::Zero),
+            None => Err(ConstraintError::NotANumber),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn integers() {
+        let one = Constrained::<_, NonZero>::new(1).unwrap();
+        assert_eq!(one.into_inner(), 1);
+
+        let neg_one = NonZero::new(-1).unwrap();
+        assert_eq!(neg_one.as_ref(), &-1);
+
+        assert!(NonZero::new(0).is_err());
+    }
+
+    #[test]
+    fn floats() {
+        assert!(Constrained::<f64, NonZero>::new(2.0).is_ok());
+        assert!(NonZero::new(-3.5).is_ok());
+        assert!(NonZero::new(0.0).is_err());
+        assert!(NonZero::new(f64::NAN).is_err());
+    }
+}

--- a/src/support/constraint/strictly_negative.rs
+++ b/src/support/constraint/strictly_negative.rs
@@ -1,0 +1,114 @@
+use std::{cmp::Ordering, marker::PhantomData, ops::Add};
+
+use num_traits::Zero;
+
+use super::{Constrained, Constraint, ConstraintError};
+
+/// Marker type enforcing that a value is strictly negative (less than zero).
+///
+/// Use this type with [`Constrained<T, StrictlyNegative>`] to encode strict
+/// negativity at the type level.
+///
+/// You can construct a value constrained to be strictly negative using
+/// either the generic [`Constrained::new`] method or the convenient
+/// [`StrictlyNegative::new`] associated function.
+///
+/// # Examples
+///
+/// ```
+/// use twine_models::support::constraint::{Constrained, StrictlyNegative};
+///
+/// // Generic constructor:
+/// let x = Constrained::<_, StrictlyNegative>::new(-1).unwrap();
+/// assert_eq!(x.into_inner(), -1);
+///
+/// // Associated constructor:
+/// let y = StrictlyNegative::new(-2.5).unwrap();
+/// assert_eq!(y.into_inner(), -2.5);
+///
+/// // Error cases:
+/// assert!(StrictlyNegative::new(0).is_err());
+/// assert!(StrictlyNegative::new(3).is_err());
+/// assert!(StrictlyNegative::new(f64::NAN).is_err());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StrictlyNegative;
+
+impl StrictlyNegative {
+    /// Constructs a [`Constrained<T, StrictlyNegative>`] if the value is strictly negative.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the value is zero, positive, or not a number (`NaN`).
+    pub fn new<T: PartialOrd + Zero>(
+        value: T,
+    ) -> Result<Constrained<T, StrictlyNegative>, ConstraintError> {
+        Constrained::<T, StrictlyNegative>::new(value)
+    }
+}
+
+impl<T: PartialOrd + Zero> Constraint<T> for StrictlyNegative {
+    fn check(value: &T) -> Result<(), ConstraintError> {
+        match value.partial_cmp(&T::zero()) {
+            Some(Ordering::Less) => Ok(()),
+            Some(Ordering::Equal) => Err(ConstraintError::Zero),
+            Some(Ordering::Greater) => Err(ConstraintError::Negative),
+            None => Err(ConstraintError::NotANumber),
+        }
+    }
+}
+
+/// Adds two `Constrained<T, StrictlyNegative>` values.
+///
+/// Assumes that summing two negative values yields a negative result.
+/// This holds for most numeric types (`i32`, `f64`, `uom::Quantity`, etc.),
+/// but may not for all possible `T`.
+/// The invariant is checked in debug builds.
+///
+/// # Panics
+///
+/// Panics in debug builds if the sum is unexpectedly non-negative.
+impl<T> Add for Constrained<T, StrictlyNegative>
+where
+    T: Add<Output = T> + PartialOrd + Zero,
+{
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        let value = self.value + rhs.value;
+        debug_assert!(
+            value < T::zero(),
+            "Addition produced a non-negative value, violating StrictlyNegative bound invariant"
+        );
+        Self {
+            value,
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn integers() {
+        let x = Constrained::<i32, StrictlyNegative>::new(-1).unwrap();
+        assert_eq!(x.into_inner(), -1);
+
+        let y = StrictlyNegative::new(-42).unwrap();
+        assert_eq!(y.as_ref(), &-42);
+
+        assert!(StrictlyNegative::new(0).is_err());
+        assert!(StrictlyNegative::new(2).is_err());
+    }
+
+    #[test]
+    fn floats() {
+        assert!(Constrained::<f64, StrictlyNegative>::new(-1.0).is_ok());
+        assert!(StrictlyNegative::new(-0.1).is_ok());
+        assert!(StrictlyNegative::new(0.0).is_err());
+        assert!(StrictlyNegative::new(5.0).is_err());
+        assert!(StrictlyNegative::new(f64::NAN).is_err());
+    }
+}

--- a/src/support/constraint/strictly_positive.rs
+++ b/src/support/constraint/strictly_positive.rs
@@ -1,0 +1,128 @@
+use std::{cmp::Ordering, marker::PhantomData, ops::Add};
+
+use num_traits::Zero;
+
+use super::{Constrained, Constraint, ConstraintError};
+
+/// Marker type enforcing that a value is strictly positive (greater than zero).
+///
+/// Use this type with [`Constrained<T, StrictlyPositive>`] to encode strict
+/// positivity at the type level.
+///
+/// You can construct a value constrained to be strictly positive using
+/// either the generic [`Constrained::new`] method or the convenient
+/// [`StrictlyPositive::new`] associated function.
+///
+/// # Examples
+///
+/// ```
+/// use twine_models::support::constraint::{Constrained, StrictlyPositive};
+///
+/// // Generic constructor:
+/// let x = Constrained::<_, StrictlyPositive>::new(1).unwrap();
+/// assert_eq!(x.into_inner(), 1);
+///
+/// // Associated constructor:
+/// let y = StrictlyPositive::new(3.14).unwrap();
+/// assert_eq!(y.into_inner(), 3.14);
+///
+/// // Error cases:
+/// assert!(StrictlyPositive::new(0).is_err());
+/// assert!(StrictlyPositive::new(-1).is_err());
+/// assert!(StrictlyPositive::new(f64::NAN).is_err());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct StrictlyPositive;
+
+impl StrictlyPositive {
+    /// Constructs a [`Constrained<T, StrictlyPositive>`] if the value is strictly positive.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the value is zero, negative, or not a number (`NaN`).
+    pub fn new<T: PartialOrd + Zero>(
+        value: T,
+    ) -> Result<Constrained<T, StrictlyPositive>, ConstraintError> {
+        Constrained::<T, StrictlyPositive>::new(value)
+    }
+}
+
+impl<T: PartialOrd + Zero> Constraint<T> for StrictlyPositive {
+    fn check(value: &T) -> Result<(), ConstraintError> {
+        match value.partial_cmp(&T::zero()) {
+            Some(Ordering::Greater) => Ok(()),
+            Some(Ordering::Equal) => Err(ConstraintError::Zero),
+            Some(Ordering::Less) => Err(ConstraintError::Negative),
+            None => Err(ConstraintError::NotANumber),
+        }
+    }
+}
+
+/// Adds two `Constrained<T, StrictlyPositive>` values.
+///
+/// Assumes that summing two positive values yields a positive result.
+/// This holds for most numeric types (`i32`, `f64`, `uom::Quantity`, etc.),
+/// but may not for all possible `T`.
+/// The invariant is checked in debug builds.
+///
+/// # Panics
+///
+/// Panics in debug builds if the sum is unexpectedly non-positive.
+impl<T> Add for Constrained<T, StrictlyPositive>
+where
+    T: Add<Output = T> + PartialOrd + Zero,
+{
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        let value = self.value + rhs.value;
+        debug_assert!(
+            value > T::zero(),
+            "Addition produced a non-positive value, violating StrictlyPositive bound invariant"
+        );
+        Self {
+            value,
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use uom::si::{f64::MassRate, mass_rate::kilogram_per_second};
+
+    #[test]
+    fn integers() {
+        let x = Constrained::<i32, StrictlyPositive>::new(1).unwrap();
+        assert_eq!(x.into_inner(), 1);
+
+        let y = StrictlyPositive::new(42).unwrap();
+        assert_eq!(y.as_ref(), &42);
+
+        assert!(StrictlyPositive::new(0).is_err());
+        assert!(StrictlyPositive::new(-2).is_err());
+    }
+
+    #[test]
+    fn floats() {
+        assert!(Constrained::<f64, StrictlyPositive>::new(1.0).is_ok());
+        assert!(StrictlyPositive::new(0.1).is_ok());
+        assert!(StrictlyPositive::new(0.0).is_err());
+        assert!(StrictlyPositive::new(-5.0).is_err());
+        assert!(StrictlyPositive::new(f64::NAN).is_err());
+    }
+
+    #[test]
+    fn mass_rates() {
+        let mass_rate = MassRate::new::<kilogram_per_second>(5.0);
+        assert!(StrictlyPositive::new(mass_rate).is_ok());
+
+        let mass_rate = MassRate::new::<kilogram_per_second>(0.0);
+        assert!(StrictlyPositive::new(mass_rate).is_err());
+
+        let mass_rate = MassRate::new::<kilogram_per_second>(-2.0);
+        assert!(StrictlyPositive::new(mass_rate).is_err());
+    }
+}

--- a/src/support/constraint/unit_interval.rs
+++ b/src/support/constraint/unit_interval.rs
@@ -1,0 +1,49 @@
+mod closed;
+mod lower_open;
+mod open;
+mod upper_open;
+
+use uom::si::{f64::Ratio, ratio::ratio};
+
+pub use closed::UnitInterval;
+pub use lower_open::UnitIntervalLowerOpen;
+pub use open::UnitIntervalOpen;
+pub use upper_open::UnitIntervalUpperOpen;
+
+/// Supplies 0 and 1 for types used in the closed unit interval [0, 1].
+///
+/// Implement this trait for your type `T` if you want to use it with
+/// `Constrained<T, UnitInterval>`.
+/// Implementations should ensure that `zero() ≤ one()` under the type's
+/// `PartialOrd` so the closed interval is well-formed.
+pub trait UnitBounds: PartialOrd {
+    fn zero() -> Self;
+    fn one() -> Self;
+}
+
+impl UnitBounds for f32 {
+    fn zero() -> Self {
+        0.0
+    }
+    fn one() -> Self {
+        1.0
+    }
+}
+
+impl UnitBounds for f64 {
+    fn zero() -> Self {
+        0.0
+    }
+    fn one() -> Self {
+        1.0
+    }
+}
+
+impl UnitBounds for Ratio {
+    fn zero() -> Self {
+        Ratio::new::<ratio>(0.0)
+    }
+    fn one() -> Self {
+        Ratio::new::<ratio>(1.0)
+    }
+}

--- a/src/support/constraint/unit_interval/closed.rs
+++ b/src/support/constraint/unit_interval/closed.rs
@@ -1,0 +1,189 @@
+use std::{cmp::Ordering, marker::PhantomData};
+
+use crate::support::constraint::{Constrained, Constraint, ConstraintError, UnitBounds};
+
+/// Marker type enforcing that a value lies in the closed unit interval: `0 ≤ x ≤ 1`.
+///
+/// Requires `T: UnitBounds`.
+/// We provide [`UnitBounds`] implementations for `f32`, `f64`, and `uom::si::f64::Ratio`.
+///
+/// You can construct a value constrained to `[0, 1]` using either the generic
+/// [`Constrained::new`] method or the convenient [`UnitInterval::new`]
+/// associated function.
+/// Convenience constructors [`UnitInterval::zero`] and [`UnitInterval::one`]
+/// are also provided for the endpoints.
+///
+/// # Examples
+///
+/// Using with `f64`:
+///
+/// ```
+/// use twine_models::support::constraint::{Constrained, UnitInterval};
+///
+/// // Generic constructor:
+/// let a = Constrained::<_, UnitInterval>::new(0.25).unwrap();
+/// assert_eq!(a.into_inner(), 0.25);
+///
+/// // Associated constructor:
+/// let b = UnitInterval::new(1.0).unwrap();
+/// assert_eq!(b.as_ref(), &1.0);
+///
+/// // Endpoints:
+/// let z = UnitInterval::zero::<f64>();
+/// let o = UnitInterval::one::<f64>();
+/// assert_eq!((z.into_inner(), o.into_inner()), (0.0, 1.0));
+///
+/// // Error cases:
+/// assert!(UnitInterval::new(-0.0001).is_err());
+/// assert!(UnitInterval::new(1.0001).is_err());
+/// assert!(UnitInterval::new(f64::NAN).is_err());
+/// ```
+///
+/// Using with `uom::si::f64::Ratio`:
+///
+/// ```
+/// use twine_models::support::constraint::{Constrained, UnitInterval};
+/// use uom::si::{f64::Ratio, ratio::{ratio, percent}};
+///
+/// let r = Constrained::<Ratio, UnitInterval>::new(Ratio::new::<ratio>(0.42)).unwrap();
+/// assert_eq!(r.as_ref().get::<percent>(), 42.0);
+///
+/// let z = UnitInterval::zero::<Ratio>();
+/// let o = UnitInterval::one::<Ratio>();
+/// assert_eq!(z.into_inner().get::<ratio>(), 0.0);
+/// assert_eq!(o.into_inner().get::<ratio>(), 1.0);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct UnitInterval;
+
+impl UnitInterval {
+    /// Constructs `Constrained<T, UnitInterval>` if 0 ≤ value ≤ 1.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the value is outside the closed unit interval:
+    ///
+    /// - [`ConstraintError::BelowMinimum`] if less than zero.
+    /// - [`ConstraintError::AboveMaximum`] if greater than one.
+    /// - [`ConstraintError::NotANumber`] if comparison is undefined (e.g., NaN).
+    pub fn new<T: UnitBounds>(value: T) -> Result<Constrained<T, UnitInterval>, ConstraintError> {
+        Constrained::<T, UnitInterval>::new(value)
+    }
+
+    /// Returns the lower bound (zero) as a constrained value.
+    #[must_use]
+    pub fn zero<T: UnitBounds>() -> Constrained<T, UnitInterval> {
+        Constrained::<T, UnitInterval> {
+            value: T::zero(),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns the upper bound (one) as a constrained value.
+    #[must_use]
+    pub fn one<T: UnitBounds>() -> Constrained<T, UnitInterval> {
+        Constrained::<T, UnitInterval> {
+            value: T::one(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T: UnitBounds> Constraint<T> for UnitInterval {
+    fn check(value: &T) -> Result<(), ConstraintError> {
+        match (value.partial_cmp(&T::zero()), value.partial_cmp(&T::one())) {
+            (None, _) | (_, None) => Err(ConstraintError::NotANumber),
+            (Some(Ordering::Less), _) => Err(ConstraintError::BelowMinimum),
+            (_, Some(Ordering::Greater)) => Err(ConstraintError::AboveMaximum),
+            _ => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::support::constraint::*;
+
+    use uom::si::{
+        f64::Ratio,
+        ratio::{percent, ratio},
+    };
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn floats_valid() {
+        assert!(Constrained::<f64, UnitInterval>::new(0.0).is_ok());
+        assert!(Constrained::<f64, UnitInterval>::new(1.0).is_ok());
+        assert!(UnitInterval::new(0.5).is_ok());
+
+        let z = UnitInterval::zero::<f64>();
+        let o = UnitInterval::one::<f64>();
+        assert_eq!(z.into_inner(), 0.0);
+        assert_eq!(o.into_inner(), 1.0);
+    }
+
+    #[test]
+    fn floats_out_of_range() {
+        assert!(matches!(
+            UnitInterval::new(-1.0),
+            Err(ConstraintError::BelowMinimum)
+        ));
+        assert!(matches!(
+            UnitInterval::new(2.0),
+            Err(ConstraintError::AboveMaximum)
+        ));
+        assert!(matches!(
+            UnitInterval::new(-1e-15),
+            Err(ConstraintError::BelowMinimum),
+        ));
+        assert!(matches!(
+            UnitInterval::new(1.0 + 1e-15),
+            Err(ConstraintError::AboveMaximum)
+        ));
+        assert!(matches!(
+            UnitInterval::new(f64::INFINITY),
+            Err(ConstraintError::AboveMaximum)
+        ));
+        assert!(matches!(
+            UnitInterval::new(f64::NEG_INFINITY),
+            Err(ConstraintError::BelowMinimum)
+        ));
+    }
+
+    #[test]
+    fn floats_nan_is_not_a_number() {
+        assert!(matches!(
+            UnitInterval::new(f64::NAN),
+            Err(ConstraintError::NotANumber)
+        ));
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn uom_ratio_valid() {
+        assert!(Constrained::<Ratio, UnitInterval>::new(Ratio::new::<ratio>(0.0)).is_ok());
+        assert!(Constrained::<Ratio, UnitInterval>::new(Ratio::new::<ratio>(1.0)).is_ok());
+        assert!(UnitInterval::new(Ratio::new::<ratio>(0.5)).is_ok());
+
+        let z = UnitInterval::zero::<Ratio>();
+        let o = UnitInterval::one::<Ratio>();
+
+        assert_eq!(z.into_inner().get::<ratio>(), 0.0);
+        assert_eq!(z.into_inner().get::<percent>(), 0.0);
+
+        assert_eq!(o.into_inner().get::<ratio>(), 1.0);
+        assert_eq!(o.into_inner().get::<percent>(), 100.0);
+    }
+
+    #[test]
+    fn uom_ratio_out_of_range() {
+        assert!(matches!(
+            UnitInterval::new(Ratio::new::<ratio>(-0.1)),
+            Err(ConstraintError::BelowMinimum)
+        ));
+        assert!(matches!(
+            UnitInterval::new(Ratio::new::<ratio>(1.1)),
+            Err(ConstraintError::AboveMaximum)
+        ));
+    }
+}

--- a/src/support/constraint/unit_interval/lower_open.rs
+++ b/src/support/constraint/unit_interval/lower_open.rs
@@ -1,0 +1,158 @@
+use std::{cmp::Ordering, marker::PhantomData};
+
+use crate::support::constraint::{Constrained, Constraint, ConstraintError};
+
+use crate::support::constraint::UnitBounds;
+
+/// Marker type enforcing that a value lies in the left-open unit interval: `0 < x ≤ 1`.
+///
+/// Requires `T: UnitBounds`.
+/// We provide [`UnitBounds`] implementations for `f32`, `f64`, and `uom::si::f64::Ratio`.
+///
+/// You can construct a value constrained to `(0, 1]` using either the generic
+/// [`Constrained::new`] method or the convenient [`UnitIntervalLowerOpen::new`]
+/// associated function.
+///
+/// # Examples
+///
+/// Using with `f64`:
+///
+/// ```
+/// use twine_models::support::constraint::{Constrained, UnitIntervalLowerOpen};
+///
+/// // Generic constructor:
+/// let a = Constrained::<_, UnitIntervalLowerOpen>::new(0.25).unwrap();
+/// assert_eq!(a.into_inner(), 0.25);
+///
+/// // Associated constructor:
+/// let b = UnitIntervalLowerOpen::new(1.0).unwrap();
+/// assert_eq!(b.as_ref(), &1.0);
+///
+/// // Endpoint:
+/// let o = UnitIntervalLowerOpen::one::<f64>();
+/// assert_eq!(o.into_inner(), 1.0);
+///
+/// // Error cases:
+/// assert!(UnitIntervalLowerOpen::new(0.0).is_err());
+/// assert!(UnitIntervalLowerOpen::new(-0.5).is_err());
+/// assert!(UnitIntervalLowerOpen::new(f64::NAN).is_err());
+/// ```
+///
+/// Using with `uom::si::f64::Ratio`:
+///
+/// ```
+/// use twine_models::support::constraint::{Constrained, UnitIntervalLowerOpen};
+/// use uom::si::{f64::Ratio, ratio::{ratio, percent}};
+///
+/// let r = Constrained::<Ratio, UnitIntervalLowerOpen>::new(Ratio::new::<ratio>(0.42)).unwrap();
+/// assert_eq!(r.as_ref().get::<percent>(), 42.0);
+///
+/// let o = UnitIntervalLowerOpen::one::<Ratio>();
+/// assert_eq!(o.into_inner().get::<percent>(), 100.0);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct UnitIntervalLowerOpen;
+
+impl UnitIntervalLowerOpen {
+    /// Constructs `Constrained<T, UnitIntervalLowerOpen>` if 0 < value ≤ 1.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the value is outside the lower-open unit interval:
+    ///
+    /// - [`ConstraintError::BelowMinimum`] if less than or equal to zero.
+    /// - [`ConstraintError::AboveMaximum`] if greater than one.
+    /// - [`ConstraintError::NotANumber`] if comparison is undefined (e.g., NaN).
+    pub fn new<T: UnitBounds>(
+        value: T,
+    ) -> Result<Constrained<T, UnitIntervalLowerOpen>, ConstraintError> {
+        Constrained::<T, UnitIntervalLowerOpen>::new(value)
+    }
+
+    /// Returns the upper bound (one) as a constrained value.
+    #[must_use]
+    pub fn one<T: UnitBounds>() -> Constrained<T, UnitIntervalLowerOpen> {
+        Constrained::<T, UnitIntervalLowerOpen> {
+            value: T::one(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T: UnitBounds> Constraint<T> for UnitIntervalLowerOpen {
+    fn check(value: &T) -> Result<(), ConstraintError> {
+        match (value.partial_cmp(&T::zero()), value.partial_cmp(&T::one())) {
+            (None, _) | (_, None) => Err(ConstraintError::NotANumber),
+            (Some(Ordering::Less | Ordering::Equal), _) => Err(ConstraintError::BelowMinimum),
+            (_, Some(Ordering::Greater)) => Err(ConstraintError::AboveMaximum),
+            _ => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::support::constraint::*;
+
+    use uom::si::{f64::Ratio, ratio::ratio};
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn floats_valid() {
+        assert!(Constrained::<f64, UnitIntervalLowerOpen>::new(0.1).is_ok());
+        assert!(Constrained::<f64, UnitIntervalLowerOpen>::new(1.0).is_ok());
+        assert!(UnitIntervalLowerOpen::new(0.75).is_ok());
+
+        let o = UnitIntervalLowerOpen::one::<f64>();
+        assert_eq!(o.into_inner(), 1.0);
+    }
+
+    #[test]
+    fn floats_out_of_range() {
+        assert!(matches!(
+            UnitIntervalLowerOpen::new(0.0),
+            Err(ConstraintError::BelowMinimum)
+        ));
+        assert!(matches!(
+            UnitIntervalLowerOpen::new(-1.0),
+            Err(ConstraintError::BelowMinimum)
+        ));
+        assert!(matches!(
+            UnitIntervalLowerOpen::new(1.000_000_1),
+            Err(ConstraintError::AboveMaximum)
+        ));
+    }
+
+    #[test]
+    fn floats_nan_is_not_a_number() {
+        assert!(matches!(
+            UnitIntervalLowerOpen::new(f64::NAN),
+            Err(ConstraintError::NotANumber)
+        ));
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn uom_ratio_valid() {
+        assert!(
+            Constrained::<Ratio, UnitIntervalLowerOpen>::new(Ratio::new::<ratio>(0.01)).is_ok()
+        );
+        assert!(Constrained::<Ratio, UnitIntervalLowerOpen>::new(Ratio::new::<ratio>(1.0)).is_ok());
+        assert!(UnitIntervalLowerOpen::new(Ratio::new::<ratio>(0.5)).is_ok());
+
+        let o = UnitIntervalLowerOpen::one::<Ratio>();
+        assert_eq!(o.into_inner().get::<ratio>(), 1.0);
+    }
+
+    #[test]
+    fn uom_ratio_out_of_range() {
+        assert!(matches!(
+            UnitIntervalLowerOpen::new(Ratio::new::<ratio>(0.0)),
+            Err(ConstraintError::BelowMinimum)
+        ));
+        assert!(matches!(
+            UnitIntervalLowerOpen::new(Ratio::new::<ratio>(1.1)),
+            Err(ConstraintError::AboveMaximum)
+        ));
+    }
+}

--- a/src/support/constraint/unit_interval/open.rs
+++ b/src/support/constraint/unit_interval/open.rs
@@ -1,0 +1,138 @@
+use std::cmp::Ordering;
+
+use crate::support::constraint::{Constrained, Constraint, ConstraintError};
+
+use crate::support::constraint::UnitBounds;
+
+/// Marker type enforcing that a value lies in the open unit interval: `0 < x < 1`.
+///
+/// Requires `T: UnitBounds`.
+/// We provide [`UnitBounds`] implementations for `f32`, `f64`, and `uom::si::f64::Ratio`.
+///
+/// You can construct a value constrained to `(0, 1)` using either the generic
+/// [`Constrained::new`] method or the convenient [`UnitIntervalOpen::new`]
+/// associated function.
+///
+/// # Examples
+///
+/// Using with `f64`:
+///
+/// ```
+/// use twine_models::support::constraint::{Constrained, UnitIntervalOpen};
+///
+/// // Generic constructor:
+/// let a = Constrained::<_, UnitIntervalOpen>::new(0.25).unwrap();
+/// assert_eq!(a.into_inner(), 0.25);
+///
+/// // Associated constructor:
+/// let b = UnitIntervalOpen::new(0.9).unwrap();
+/// assert_eq!(b.as_ref(), &0.9);
+///
+/// // Error cases:
+/// assert!(UnitIntervalOpen::new(0.0).is_err());
+/// assert!(UnitIntervalOpen::new(1.0).is_err());
+/// assert!(UnitIntervalOpen::new(f64::NAN).is_err());
+/// ```
+///
+/// Using with `uom::si::f64::Ratio`:
+///
+/// ```
+/// use twine_models::support::constraint::{Constrained, UnitIntervalOpen};
+/// use uom::si::{f64::Ratio, ratio::{ratio, percent}};
+///
+/// let r = Constrained::<Ratio, UnitIntervalOpen>::new(Ratio::new::<ratio>(0.42)).unwrap();
+/// assert_eq!(r.as_ref().get::<percent>(), 42.0);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct UnitIntervalOpen;
+
+impl UnitIntervalOpen {
+    /// Constructs `Constrained<T, UnitIntervalOpen>` if 0 < value < 1.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the value is outside the open unit interval:
+    ///
+    /// - [`ConstraintError::BelowMinimum`] if less than or equal to zero.
+    /// - [`ConstraintError::AboveMaximum`] if greater than or equal to one.
+    /// - [`ConstraintError::NotANumber`] if comparison is undefined (e.g., NaN).
+    pub fn new<T: UnitBounds>(
+        value: T,
+    ) -> Result<Constrained<T, UnitIntervalOpen>, ConstraintError> {
+        Constrained::<T, UnitIntervalOpen>::new(value)
+    }
+}
+
+impl<T: UnitBounds> Constraint<T> for UnitIntervalOpen {
+    fn check(value: &T) -> Result<(), ConstraintError> {
+        match (value.partial_cmp(&T::zero()), value.partial_cmp(&T::one())) {
+            (None, _) | (_, None) => Err(ConstraintError::NotANumber),
+            (Some(Ordering::Less | Ordering::Equal), _) => Err(ConstraintError::BelowMinimum),
+            (_, Some(Ordering::Greater | Ordering::Equal)) => Err(ConstraintError::AboveMaximum),
+            _ => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::support::constraint::*;
+
+    use uom::si::{f64::Ratio, ratio::ratio};
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn floats_valid() {
+        assert!(Constrained::<f64, UnitIntervalOpen>::new(0.1).is_ok());
+        assert!(Constrained::<f64, UnitIntervalOpen>::new(0.9).is_ok());
+        assert!(UnitIntervalOpen::new(0.5).is_ok());
+    }
+
+    #[test]
+    fn floats_out_of_range() {
+        assert!(matches!(
+            UnitIntervalOpen::new(0.0),
+            Err(ConstraintError::BelowMinimum)
+        ));
+        assert!(matches!(
+            UnitIntervalOpen::new(-1.0),
+            Err(ConstraintError::BelowMinimum)
+        ));
+        assert!(matches!(
+            UnitIntervalOpen::new(1.0),
+            Err(ConstraintError::AboveMaximum)
+        ));
+        assert!(matches!(
+            UnitIntervalOpen::new(2.0),
+            Err(ConstraintError::AboveMaximum)
+        ));
+    }
+
+    #[test]
+    fn floats_nan_is_not_a_number() {
+        assert!(matches!(
+            UnitIntervalOpen::new(f64::NAN),
+            Err(ConstraintError::NotANumber)
+        ));
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn uom_ratio_valid() {
+        assert!(Constrained::<Ratio, UnitIntervalOpen>::new(Ratio::new::<ratio>(0.01)).is_ok());
+        assert!(Constrained::<Ratio, UnitIntervalOpen>::new(Ratio::new::<ratio>(0.99)).is_ok());
+        assert!(UnitIntervalOpen::new(Ratio::new::<ratio>(0.5)).is_ok());
+    }
+
+    #[test]
+    fn uom_ratio_out_of_range() {
+        assert!(matches!(
+            UnitIntervalOpen::new(Ratio::new::<ratio>(0.0)),
+            Err(ConstraintError::BelowMinimum)
+        ));
+        assert!(matches!(
+            UnitIntervalOpen::new(Ratio::new::<ratio>(1.0)),
+            Err(ConstraintError::AboveMaximum)
+        ));
+    }
+}

--- a/src/support/constraint/unit_interval/upper_open.rs
+++ b/src/support/constraint/unit_interval/upper_open.rs
@@ -1,0 +1,158 @@
+use std::{cmp::Ordering, marker::PhantomData};
+
+use crate::support::constraint::{Constrained, Constraint, ConstraintError};
+
+use crate::support::constraint::UnitBounds;
+
+/// Marker type enforcing that a value lies in the right-open unit interval: `0 ≤ x < 1`.
+///
+/// Requires `T: UnitBounds`.
+/// We provide [`UnitBounds`] implementations for `f32`, `f64`, and `uom::si::f64::Ratio`.
+///
+/// You can construct a value constrained to `[0, 1)` using either the generic
+/// [`Constrained::new`] method or the convenient [`UnitIntervalUpperOpen::new`]
+/// associated function.
+///
+/// # Examples
+///
+/// Using with `f64`:
+///
+/// ```
+/// use twine_models::support::constraint::{Constrained, UnitIntervalUpperOpen};
+///
+/// // Generic constructor:
+/// let a = Constrained::<_, UnitIntervalUpperOpen>::new(0.25).unwrap();
+/// assert_eq!(a.into_inner(), 0.25);
+///
+/// // Associated constructor:
+/// let b = UnitIntervalUpperOpen::new(0.0).unwrap();
+/// assert_eq!(b.as_ref(), &0.0);
+///
+/// // Endpoint:
+/// let z = UnitIntervalUpperOpen::zero::<f64>();
+/// assert_eq!(z.into_inner(), 0.0);
+///
+/// // Error cases:
+/// assert!(UnitIntervalUpperOpen::new(1.0).is_err());
+/// assert!(UnitIntervalUpperOpen::new(1.5).is_err());
+/// assert!(UnitIntervalUpperOpen::new(f64::NAN).is_err());
+/// ```
+///
+/// Using with `uom::si::f64::Ratio`:
+///
+/// ```
+/// use twine_models::support::constraint::{Constrained, UnitIntervalUpperOpen};
+/// use uom::si::{f64::Ratio, ratio::{ratio, percent}};
+///
+/// let r = Constrained::<Ratio, UnitIntervalUpperOpen>::new(Ratio::new::<ratio>(0.42)).unwrap();
+/// assert_eq!(r.as_ref().get::<percent>(), 42.0);
+///
+/// let z = UnitIntervalUpperOpen::zero::<Ratio>();
+/// assert_eq!(z.into_inner().get::<percent>(), 0.0);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct UnitIntervalUpperOpen;
+
+impl UnitIntervalUpperOpen {
+    /// Constructs `Constrained<T, UnitIntervalUpperOpen>` if 0 ≤ value < 1.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the value is outside the upper-open unit interval:
+    ///
+    /// - [`ConstraintError::BelowMinimum`] if less than zero.
+    /// - [`ConstraintError::AboveMaximum`] if greater than or equal to one.
+    /// - [`ConstraintError::NotANumber`] if comparison is undefined (e.g., NaN).
+    pub fn new<T: UnitBounds>(
+        value: T,
+    ) -> Result<Constrained<T, UnitIntervalUpperOpen>, ConstraintError> {
+        Constrained::<T, UnitIntervalUpperOpen>::new(value)
+    }
+
+    /// Returns the lower bound (zero) as a constrained value.
+    #[must_use]
+    pub fn zero<T: UnitBounds>() -> Constrained<T, UnitIntervalUpperOpen> {
+        Constrained::<T, UnitIntervalUpperOpen> {
+            value: T::zero(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T: UnitBounds> Constraint<T> for UnitIntervalUpperOpen {
+    fn check(value: &T) -> Result<(), ConstraintError> {
+        match (value.partial_cmp(&T::zero()), value.partial_cmp(&T::one())) {
+            (None, _) | (_, None) => Err(ConstraintError::NotANumber),
+            (Some(Ordering::Less), _) => Err(ConstraintError::BelowMinimum),
+            (_, Some(Ordering::Greater | Ordering::Equal)) => Err(ConstraintError::AboveMaximum),
+            _ => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::support::constraint::*;
+
+    use uom::si::{f64::Ratio, ratio::ratio};
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn floats_valid() {
+        assert!(Constrained::<f64, UnitIntervalUpperOpen>::new(0.0).is_ok());
+        assert!(Constrained::<f64, UnitIntervalUpperOpen>::new(0.9).is_ok());
+        assert!(UnitIntervalUpperOpen::new(0.5).is_ok());
+
+        let z = UnitIntervalUpperOpen::zero::<f64>();
+        assert_eq!(z.into_inner(), 0.0);
+    }
+
+    #[test]
+    fn floats_out_of_range() {
+        assert!(matches!(
+            UnitIntervalUpperOpen::new(-1.0),
+            Err(ConstraintError::BelowMinimum)
+        ));
+        assert!(matches!(
+            UnitIntervalUpperOpen::new(1.0),
+            Err(ConstraintError::AboveMaximum)
+        ));
+        assert!(matches!(
+            UnitIntervalUpperOpen::new(2.0),
+            Err(ConstraintError::AboveMaximum)
+        ));
+    }
+
+    #[test]
+    fn floats_nan_is_not_a_number() {
+        assert!(matches!(
+            UnitIntervalUpperOpen::new(f64::NAN),
+            Err(ConstraintError::NotANumber)
+        ));
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn uom_ratio_valid() {
+        assert!(Constrained::<Ratio, UnitIntervalUpperOpen>::new(Ratio::new::<ratio>(0.0)).is_ok());
+        assert!(
+            Constrained::<Ratio, UnitIntervalUpperOpen>::new(Ratio::new::<ratio>(0.99)).is_ok()
+        );
+        assert!(UnitIntervalUpperOpen::new(Ratio::new::<ratio>(0.5)).is_ok());
+
+        let z = UnitIntervalUpperOpen::zero::<Ratio>();
+        assert_eq!(z.into_inner().get::<ratio>(), 0.0);
+    }
+
+    #[test]
+    fn uom_ratio_out_of_range() {
+        assert!(matches!(
+            UnitIntervalUpperOpen::new(Ratio::new::<ratio>(-0.1)),
+            Err(ConstraintError::BelowMinimum)
+        ));
+        assert!(matches!(
+            UnitIntervalUpperOpen::new(Ratio::new::<ratio>(1.0)),
+            Err(ConstraintError::AboveMaximum)
+        ));
+    }
+}


### PR DESCRIPTION
This PR:

 - Adds `support::constraint` module for type-level numeric constraints
 - Adds CI workflow with formatting checks, clippy, and tests
 - Polishes crate-level documentation and aligns descriptions
- Adds `twine-core` dependency (via git until 0.5 is published) for doc link support
