### PR TITLE
Enforce no mod.rs files via clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ coolprop = ["dep:rfluids"]
 
 [dev-dependencies]
 approx = "0.5"
+
+[lints.clippy]
+# Enforce `foo.rs` + `foo/` module style over `foo/mod.rs`
+mod_module_files = "deny"


### PR DESCRIPTION
Adds `clippy::mod_module_files = "deny"` to `Cargo.toml` to enforce the modern `foo.rs` + `foo/` module style over `foo/mod.rs`.

This addresses the preference expressed in https://github.com/isentropic-dev/twine-models/issues/11#issuecomment-3891737472

The lint will cause CI to fail if anyone adds a `mod.rs` file, providing clear guidance to use the preferred style instead.