### PR TITLE
Improve models::thermal module docs

### DIFF
--- a/src/models/thermal.rs
+++ b/src/models/thermal.rs
@@ -1,7 +1,20 @@
-//! Thermal systems models.
+//! Thermal component models.
 //!
-//! This module contains models for thermal systems including heat exchangers,
-//! thermal storage, and related components.
+//! Each submodule covers a category of thermal component.
+//! Individual models live inside their category module.
+//!
+//! ## Available models
+//!
+//! - **Heat exchangers** ([`hx`]) — [`Recuperator`]: counterflow heat recovery
+//!   between two streams of the same working fluid, discretized into segments
+//!   for real-fluid accuracy.
+//!
+//! - **Tanks** ([`tank`]) — [`StratifiedTank`]: vertical thermal storage tank
+//!   discretized into fully mixed nodes, with port pairs, auxiliary heat
+//!   sources, buoyancy mixing, and conduction.
+//!
+//! [`Recuperator`]: hx::discretized::Recuperator
+//! [`StratifiedTank`]: tank::stratified::StratifiedTank
 
 pub mod hx;
 pub mod tank;


### PR DESCRIPTION
Replaces the generic "thermal systems models" description with a catalog of available models, each with a brief description and a doc link.

The idea is that this module becomes the entry point for discovering what thermal models exist. As models are added, they get a line here.
