### PR TITLE
Make coolprop feature opt-in

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ twine-solvers = "0.5"
 uom = "0.36"
 
 [features]
-default = ["coolprop"]
+default = []
 coolprop = ["dep:rfluids"]
 plot = ["dep:twine-observers", "twine-observers/plot"]
 


### PR DESCRIPTION
Removes `coolprop` from the default features so consumers who don't need CoolProp (WASM targets, embedded environments, or anyone using only `PerfectGas`/`Incompressible`) get a lighter dependency tree without having to set `default-features = false`.

Consumers that need CoolProp opt in explicitly:

```toml
twine-models = { version = "...", features = ["coolprop"] }
```

Closes #39.
