### PR TITLE
Prepare 0.2.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3138,7 +3138,7 @@ checksum = "ff0c319e9838813ab378aea2a73615e9c060dbe6bc0f35688006545185be2968"
 
 [[package]]
 name = "twine-models"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "approx",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "twine-models"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["Isentropic Development <info@isentropic.dev>"]
 license = "MIT"
 repository = "https://github.com/isentropic-dev/twine-models"
 readme = "README.md"
 description = "Domain-specific models and model-building tools for Twine"
+exclude = ["vendor/"]
 
 [dependencies]
 num-traits = "0.2"

--- a/README.md
+++ b/README.md
@@ -27,14 +27,41 @@ See the [crate docs](https://docs.rs/twine-models) for details on each module.
 
 ## Feature flags
 
-| Feature    | What it enables                                    | Default |
-|------------|----------------------------------------------------|---------|
-| `coolprop` | `support::thermo::model::CoolProp` (via `rfluids`) | no      |
+| Feature          | What it enables                                          | Default |
+|------------------|----------------------------------------------------------|---------|
+| `coolprop-dylib` | `CoolProp` model via prebuilt shared library             | no      |
+| `coolprop-static`| `CoolProp` model compiled from source (cmake + vendored) | no      |
 
-Opt in via `Cargo.toml`:
+The two CoolProp features are mutually exclusive.
+
+### `coolprop-dylib`
+
+Links against prebuilt shared libraries from platform-specific `coolprop-sys-*` crates.
+Fast builds, good for local development. Works from crates.io.
 
 ```toml
-twine-models = { version = "0.1", features = ["coolprop"] }
+twine-models = { version = "0.2", features = ["coolprop-dylib"] }
+```
+
+### `coolprop-static`
+
+Compiles CoolProp from source as a static library via cmake.
+Slower first build (cached after), but self-contained.
+Works for native, Python wheels, and WASM (`wasm32-unknown-emscripten`).
+
+**Requires a git clone with submodules** — the CoolProp source tree (~240MB) exceeds
+crates.io's package size limit, so this feature is not available from a crates.io install.
+
+```sh
+git clone --recurse-submodules https://github.com/isentropic-dev/twine-models
+```
+
+For WASM builds, the Emscripten SDK must be installed with `em-config` on PATH:
+
+```sh
+brew install emscripten        # macOS
+rustup target add wasm32-unknown-emscripten
+cargo test --target wasm32-unknown-emscripten --features coolprop-static --tests
 ```
 
 ## Examples


### PR DESCRIPTION
## What

Prepare 0.2.0 release for crates.io. Closes #52.

New in this release: `coolprop-dylib` and `coolprop-static` features (#45), plus WASM support via Emscripten (#48).

## Changes

- Bump version to 0.2.0.
- Exclude `vendor/` from the crates.io package. The CoolProp source tree is ~240MB (76MB in fluid data headers alone), well over the 10MB limit. `coolprop-static` requires a git clone with submodules; `coolprop-dylib` and featureless builds work from crates.io.
- Update README to document both CoolProp features and their installation requirements.
