### PR TITLE
Fix coolprop-static build: COOLPROP_SOURCE_DIR env var and install_root leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ crates.io's package size limit, so this feature is not available from a crates.i
 git clone --recurse-submodules https://github.com/isentropic-dev/twine-models
 ```
 
+#### `COOLPROP_SOURCE_DIR`
+
+If you have a local CoolProp checkout (e.g., when installing from crates.io), set
+`COOLPROP_SOURCE_DIR` to point `build.rs` at it instead of the vendored submodule:
+
+```sh
+COOLPROP_SOURCE_DIR=/path/to/CoolProp cargo build --features coolprop-static
+```
+
 For WASM builds, the Emscripten SDK must be installed with `em-config` on PATH:
 
 ```sh

--- a/build.rs
+++ b/build.rs
@@ -17,7 +17,15 @@ mod coolprop_static {
     pub fn build() {
         let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
         let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-        let source_dir = manifest_dir.join("vendor/CoolProp");
+
+        // Allow COOLPROP_SOURCE_DIR to override the default vendor location.
+        // This lets crates.io consumers point at a local CoolProp checkout
+        // instead of requiring a full git clone with submodules.
+        println!("cargo:rerun-if-env-changed=COOLPROP_SOURCE_DIR");
+        let source_dir = env::var("COOLPROP_SOURCE_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| manifest_dir.join("vendor/CoolProp"));
+
         let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
 
         // Rebuild if the build script or the CoolProp header changes.
@@ -55,6 +63,15 @@ mod coolprop_static {
             .define(
                 "CMAKE_ARCHIVE_OUTPUT_DIRECTORY",
                 lib_dir.to_str().expect("lib_dir path is valid UTF-8"),
+            )
+            // Redirect cmake's install step into OUT_DIR so it doesn't write
+            // install_root/ into the CoolProp source tree (see issue #56).
+            .define(
+                "CMAKE_INSTALL_PREFIX",
+                out_dir
+                    .join("coolprop-install")
+                    .to_str()
+                    .expect("out_dir path is valid UTF-8"),
             )
             .build();
 
@@ -132,6 +149,15 @@ mod coolprop_static {
                 &format!(
                     "-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY={}",
                     lib_dir.to_str().expect("lib_dir path is valid UTF-8")
+                ),
+                // Redirect cmake's install step into OUT_DIR so it doesn't write
+                // install_root/ into the CoolProp source tree (see issue #56).
+                &format!(
+                    "-DCMAKE_INSTALL_PREFIX={}",
+                    out_dir
+                        .join("coolprop-install")
+                        .to_str()
+                        .expect("out_dir path is valid UTF-8")
                 ),
             ])
             .status()


### PR DESCRIPTION
## What

Two fixes to the `coolprop-static` build path in `build.rs`, surfaced during Brayton cycle work in a downstream repo that depends on `twine-models`.

**`COOLPROP_SOURCE_DIR` env var (#57):** `coolprop-static` requires a git clone with submodules because the CoolProp source tree exceeds crates.io's size limit. Crates.io consumers had no way to use the feature. Adding `COOLPROP_SOURCE_DIR` lets them point `build.rs` at a local checkout:

```sh
COOLPROP_SOURCE_DIR=/path/to/CoolProp cargo build --features coolprop-static
```

**cmake install leak (#56):** `cargo build --features coolprop-static` was writing an `install_root/` directory into the CoolProp source tree as a side effect of the cmake install step. We don't use that output (the library goes to `OUT_DIR/lib` via `CMAKE_ARCHIVE_OUTPUT_DIRECTORY`), but it dirtied the submodule working directory and caused issues during the 0.2.0 publish.

## How

- In `build()`, check `COOLPROP_SOURCE_DIR` before falling back to `vendor/CoolProp`. Emit `cargo:rerun-if-env-changed=COOLPROP_SOURCE_DIR`.
- In `build_native()`, add `.define("CMAKE_INSTALL_PREFIX", out_dir.join("coolprop-install"))` to redirect the install step inside `OUT_DIR`.
- In `build_wasm()`, add the matching `-DCMAKE_INSTALL_PREFIX=...` arg to the cmake configure invocation.
- Document `COOLPROP_SOURCE_DIR` in the README under `coolprop-static`.

Closes #56
Closes #57
