### PR TITLE
Prepare 0.2.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twine-models"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Isentropic Development <info@isentropic.dev>"]
 license = "MIT"


### PR DESCRIPTION
## What

Prepare 0.2.1 patch release for crates.io.

Fixes since 0.2.0:

- **Recuperator convergence bug** (#59): Fixed a convergence failure in the recuperator model when CoolProp is enabled.
- **CoolProp CI** (#59): CoolProp features are now tested in CI.
- **`COOLPROP_SOURCE_DIR` env var** (#57, #60): Crates.io consumers of `coolprop-static` can now point `build.rs` at a local CoolProp checkout instead of relying on the vendored submodule.
- **cmake install leak** (#56, #60): The `coolprop-static` build no longer writes an `install_root/` directory into the CoolProp source tree.

## Changes

- Bump version to 0.2.1.
