### PR TITLE
Fix recuperator bisection bracket failure on wasm

### DIFF
--- a/src/models/thermal/hx/discretized/core/given_ua.rs
+++ b/src/models/thermal/hx/discretized/core/given_ua.rs
@@ -4,6 +4,17 @@
 //! the top stream outlet temperature until the achieved conductance converges
 //! to the desired value.
 
+/// Temperature threshold (in kelvin) for distinguishing FP noise from real
+/// heat transfer at the bisection bracket boundary.
+///
+/// When the candidate top outlet temperature is within this distance of the
+/// top inlet temperature, any `SecondLawViolation` is treated as numerical
+/// noise (UA ≈ 0) rather than a genuine overshoot.
+///
+/// The value is three orders of magnitude below the solver's default
+/// temperature tolerance (1e-6 K), so it won't interfere with real solutions.
+const INLET_PROXIMITY_THRESHOLD_K: f64 = 1e-9;
+
 mod config;
 mod error;
 mod problem;
@@ -103,7 +114,7 @@ where
                 // so UA ≈ 0 and the residual is negative.
                 // Farther away, it's a genuine overshoot — the candidate
                 // outlet temperature exceeds physical limits.
-                let near_inlet = (event.x() - t_top_in).abs() < 1e-9;
+                let near_inlet = (event.x() - t_top_in).abs() < INLET_PROXIMITY_THRESHOLD_K;
                 return Some(if near_inlet {
                     bisection::Action::assume_negative()
                 } else {


### PR DESCRIPTION
## What

Fixes the recuperator "invalid bracket: no sign change" error on wasm targets with segments > 1.

On wasm (strict IEEE 754, no x86 extended precision), CoolProp's enthalpy round-trip noise at the lower bracket boundary (`t_out = t_in`) can exceed the `ENTHALPY_RELATIVE_ZERO` threshold from #59. When the noise produces a spurious wrong-direction heat flow, the resolve step emits a `SecondLawViolation`. The event handler was mapping *all* such violations to `assume_positive` — correct for genuine overshoots mid-iteration, but wrong at the zero-heat-transfer boundary where UA ≈ 0 and the residual should be negative. Both endpoints end up positive → bracket rejected.

## How

The event handler now checks whether the candidate `t_out` is near `t_top_in` (within 1e-9 K). Near the inlet, a `SecondLawViolation` is FP noise → `assume_negative`. Farther away, it's a real overshoot → `assume_positive`.

The `ENTHALPY_RELATIVE_ZERO` threshold is unchanged — it's still the first line of defense in the resolve step. The event handler is the fallback for when the thermo backend's noise exceeds it.

Closes #63
