### PR TITLE
Prepare 0.2.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3138,7 +3138,7 @@ checksum = "ff0c319e9838813ab378aea2a73615e9c060dbe6bc0f35688006545185be2968"
 
 [[package]]
 name = "twine-models"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "approx",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twine-models"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 authors = ["Isentropic Development <info@isentropic.dev>"]
 license = "MIT"


### PR DESCRIPTION
## What

Bump version to 0.2.2 for patch release.

### Since 0.2.1

- Fix recuperator bisection bracket failure on wasm with segments > 1 (#64, closes #63)
